### PR TITLE
Add: v2 YAML file format

### DIFF
--- a/data-to-be.yaml
+++ b/data-to-be.yaml
@@ -3,16 +3,20 @@ this project:
   yaml:
   rich text:
     color:
-      mm-font-color: ff0000  # HEX
+      __attrs:
+        font-color: ff0000  # HEX
     icon:
-      mm-icon: fa-heart  # Font Awsome
+      __attrs:
+        icon: fa-heart  # Font Awsome
     background:
-      mm-background: 0000ff  # HEX
-    allinment:
+      __attrs:
+        background: 0000ff  # HEX
+    alignment:
   d3j:
   tooling:
     GitHub:
-      mm-hyperlink: https://github.com/kisst/mindmap
+      __attrs:
+        hyperlink: https://github.com/kisst/mindmap
   MVP:
     It works:
   Design principals:


### PR DESCRIPTION
* The new expected input data should conform to the `data-to-be.yaml`
  format, where - at its simplest - each node needs to be on a single
  line, with a comma at the end
* Fixes #3