### PR TITLE
Fix: Center the root node when no initial given

### DIFF
--- a/javascripts/mindmap.js
+++ b/javascripts/mindmap.js
@@ -664,7 +664,7 @@ function processInitialNodes(root) {
   const initial = getUrlParam('initial');
 
   if (!initial) {
-    return;
+    return root;
   }
 
   const toMatch = initial.trim().split('.');


### PR DESCRIPTION
* When no `initial` was given, instead of returning the root node, this method returned `undefined`
* As such, nothing was being centered.