### PR TITLE
Fix: The background to cover an icon when set

### DIFF
--- a/javascripts/mindmap.js
+++ b/javascripts/mindmap.js
@@ -173,7 +173,7 @@ var root;
 
 // size of the diagram
 var viewerWidth = $(document).width();
-var viewerHeight = $(document).height()-40;
+var viewerHeight = $(document).height() - 40;
 
 var tree = d3.layout.tree()
   .size([viewerHeight, viewerWidth]);
@@ -601,29 +601,6 @@ function update(source) {
       outCircle(node);
     });
 
-  // Add a `rect` to provide a background to all applicable nodes
-  nodeEnter
-    .filter(d => !!d.attrs.background)
-    .append('rect')
-    .style('opacity', 0)
-    .each(function (d) {
-      const parent = this.parentElement;
-      const parentBound = parent.getBBox();
-
-      const paddingY = 1;
-      const paddingX = 2;
-
-      d3.select(this).attr({
-        fill: `#${d.attrs.background}`,
-        x: parentBound.x - paddingX,
-        y: parentBound.y - paddingY,
-        width: parentBound.width + (paddingX * 2),
-        height: parentBound.height + (paddingY * 2),
-      });
-
-      parent.insertBefore(this, parent.firstChild);
-    })
-
   // Update the text to reflect whether node has children or not.
   node.select('text')
     .attr("x", function (d) {
@@ -666,6 +643,29 @@ function update(source) {
 
       return text;
     });
+
+  // Add a `rect` to provide a background to all applicable nodes
+  nodeEnter
+    .filter(d => !!d.attrs.background)
+    .append('rect')
+    .style('opacity', 0)
+    .each(function (d) {
+      const parent = this.parentElement;
+      const parentBound = parent.getBBox();
+
+      const paddingY = 1;
+      const paddingX = 2;
+
+      d3.select(this).attr({
+        fill: `#${d.attrs.background}`,
+        x: parentBound.x - paddingX,
+        y: parentBound.y - paddingY,
+        width: parentBound.width + (paddingX * 2),
+        height: parentBound.height + (paddingY * 2),
+      });
+
+      parent.insertBefore(this, parent.firstChild);
+    })
 
   // Change the circle fill depending on whether it has children and is collapsed
   node.select("circle.nodeCircle")


### PR DESCRIPTION
* Sets the icon to be appended _before_ setting the background, so as to correctly determine the positioning 

![image](https://user-images.githubusercontent.com/3514018/80916303-5f57b780-8d47-11ea-9df1-a9632bcad0b8.png)
